### PR TITLE
Generate grammar combinations dynamically

### DIFF
--- a/knotify/grammars/pseudoknot.py
+++ b/knotify/grammars/pseudoknot.py
@@ -1,44 +1,12 @@
+import itertools
+
 import jinja2
 
 TEMPLATE = """
-S : 'a' L 'a' D 'u' L 'u' # R01 (1 3 5)
-  | 'a' L 'g' D 'u' L 'c' # R02 (1 3 5)
-  | 'a' L 'u' D 'u' L 'a' # R03 (1 3 5)
-  | 'a' L 'c' D 'u' L 'g' # R04 (1 3 5)
-  | 'g' L 'a' D 'c' L 'u' # R05 (1 3 5)
-  | 'g' L 'g' D 'c' L 'c' # R06 (1 3 5)
-  | 'g' L 'u' D 'c' L 'a' # R07 (1 3 5)
-  | 'g' L 'c' D 'c' L 'g' # R08 (1 3 5)
-  | 'u' L 'a' D 'a' L 'u' # R09 (1 3 5)
-  | 'u' L 'g' D 'a' L 'c' # R10 (1 3 5)
-  | 'u' L 'u' D 'a' L 'a' # R11 (1 3 5)
-  | 'u' L 'c' D 'a' L 'g' # R12 (1 3 5)
-  | 'c' L 'a' D 'g' L 'u' # R13 (1 3 5)
-  | 'c' L 'g' D 'g' L 'c' # R14 (1 3 5)
-  | 'c' L 'u' D 'g' L 'a' # R15 (1 3 5)
-  | 'c' L 'c' D 'g' L 'g' # R16 (1 3 5)
-{% if allow_ug %}
-  | 'a' L 'g' D 'u' L 'u' # R17 (1 3 5)
-  | 'a' L 'u' D 'u' L 'g' # R18 (1 3 5)
-  | 'g' L 'g' D 'c' L 'u' # R19 (1 3 5)
-  | 'g' L 'u' D 'c' L 'g' # R20 (1 3 5)
-  | 'g' L 'a' D 'u' L 'u' # R21 (1 3 5)
-  | 'g' L 'g' D 'u' L 'c' # R22 (1 3 5)
-  | 'g' L 'g' D 'u' L 'u' # R23 (1 3 5)
-  | 'g' L 'u' D 'u' L 'a' # R24 (1 3 5)
-  | 'g' L 'c' D 'u' L 'g' # R25 (1 3 5)
-  | 'g' L 'u' D 'u' L 'g' # R26 (1 3 5)
-  | 'u' L 'g' D 'a' L 'u' # R27 (1 3 5)
-  | 'u' L 'u' D 'a' L 'g' # R28 (1 3 5)
-  | 'c' L 'g' D 'g' L 'u' # R29 (1 3 5)
-  | 'c' L 'u' D 'g' L 'g' # R30 (1 3 5)
-  | 'u' L 'a' D 'g' L 'u' # R31 (1 3 5)
-  | 'u' L 'g' D 'g' L 'c' # R32 (1 3 5)
-  | 'u' L 'g' D 'g' L 'u' # R33 (1 3 5)
-  | 'u' L 'u' D 'g' L 'a' # R34 (1 3 5)
-  | 'u' L 'c' D 'g' L 'g' # R35 (1 3 5)
-  | 'u' L 'u' D 'g' L 'g' # R36 (1 3 5)
-{% endif %}
+S :
+{% for idx, (p1, p2) in combinations %}
+  | '{{ p1[0] }}' L '{{ p2[0] }}' D '{{ p1[1] }}' L '{{ p2[1] }}' # R{{ idx }} (1 3 5)
+{% endfor %}
   ;
 
 L : 'a' L # L1 (1)
@@ -69,11 +37,16 @@ def generate_grammar(allow_ug: bool, max_dd_size: int) -> str:
     """
     Generate grammar for pseudoknot detection, based on parameters.
     """
+    allowed_pairs = {
+        True: ["au", "gc", "ua", "cg", "gu", "ug"],
+        False: ["au", "gc", "ua", "cg"],
+    }[allow_ug]
+
     return (
         jinja2.Environment()
         .from_string(TEMPLATE)
         .render(
-            allow_ug=allow_ug,
+            combinations=enumerate(itertools.product(allowed_pairs, allowed_pairs)),
             max_dd_size=max_dd_size,
         )
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -34,11 +34,23 @@ def test_max_dd_size(dd_size: int, sequence: str, result: List[str]):
     ),
 )
 def test_pseudoknot_pairs(A, B, allow_ug):
-    parser = PseudoknotDetector(grammar=PSEUDOKNOT, max_dd_size=1, allow_ug=allow_ug)
+    parser = PseudoknotDetector(grammar=PSEUDOKNOT, max_dd_size=4, allow_ug=allow_ug)
     combination_has_ug = any(x in ["gu", "ug"] for x in [A, B])
 
-    result = parser.detect_pseudoknots("{}aaa{}a{}aaa{}".format(A[0], B[0], A[1], B[1]))
+    result = parser.detect_pseudoknots(
+        "".join(
+            [
+                A[0],  # left core outer
+                "augcaugc",  # left loop
+                B[0],  # right core inner
+                "augc",  # dd
+                A[1],  # left core inner
+                "augcaugc",  # right loop
+                B[1],  # right core outer
+            ]
+        )
+    )
     if not combination_has_ug or combination_has_ug and allow_ug:
-        assert "3, 1" in result
+        assert "8, 4" in result
     if combination_has_ug and not allow_ug:
-        assert "3, 1" not in result
+        assert "8, 4" not in result


### PR DESCRIPTION
### Summary

This reduces the burden of maintaining a hand-written
list of pairs allowed to form pseudoknots.

Unit tests make sure that no regressions are introduced.

Understandably, this is slightly easier to maintain code-wise
but makes the grammar itself a bit harder to reason about.

### Changes

- Dynamically generate all grammar rules based on the allowed combinations.