### PR TITLE
Upgrade jinja to 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 biopython==1.76
 pandas==1.2.2
 levenshtein==0.12.0
-jinja2==2.11.3
+jinja2==3.0.3
 pyyaml==5.4.1


### PR DESCRIPTION
### Summary

Upgrade Jinja to latest version, also fixes

```
Traceback (most recent call last):
  File ".venv/bin/rna_analysis", line 6, in <module>
    from knotify.main import main
  File "/home/runner/work/knotify/knotify/knotify/main.py", line 26, in <module>
    from knotify import hairpin
  File "/home/runner/work/knotify/knotify/knotify/hairpin.py", line 29, in <module>
    from knotify.grammars.hairpin import generate_grammar
  File "/home/runner/work/knotify/knotify/knotify/grammars/hairpin.py", line 23, in <module>
    import jinja2
  File "/home/runner/work/knotify/knotify/.venv/lib/python3.[8](https://github.com/ntua-dslab/knotify/runs/5483163915?check_suite_focus=true#step:6:8)/site-packages/jinja2/__init__.py", line [12](https://github.com/ntua-dslab/knotify/runs/5483163915?check_suite_focus=true#step:6:12), in <module>
    from .environment import Environment
  File "/home/runner/work/knotify/knotify/.venv/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/home/runner/work/knotify/knotify/.venv/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/home/runner/work/knotify/knotify/.venv/lib/python3.8/site-packages/jinja2/filters.py", line [13](https://github.com/ntua-dslab/knotify/runs/5483163915?check_suite_focus=true#step:6:13), in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/runner/work/knotify/knotify/.venv/lib/python3.8/site-packages/markupsafe/__init__.py)
```