### PR TITLE
Use structured configuration options

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Build package
         run: make deps && make -j
       - name: rna_analysis
-        run: ./.venv/bin/rna_analysis AUCCUUUUCAGUUGGGCCUUCUGGUGAUGUUUCUGGCCACCCAGGAGGUCCUGAGGAAGAGGUGGACGGCCAGAUUGACU --parser yaep
+        run: ./.venv/bin/rna_analysis --sequence AUCCUUUUCAGUUGGGCCUUCUGGUGAUGUUUCUGGCCACCCAGGAGGUCCUGAGGAAGAGGUGGACGGCCAGAUUGACU
       - name: rna_benchmark
-        run: ./.venv/bin/rna_benchmark --parser yaep --cases cases/cases.yaml --verbose
+        run: ./.venv/bin/rna_benchmark --cases cases/cases.yaml --verbose

--- a/README.md
+++ b/README.md
@@ -45,19 +45,23 @@ $ make deps  # install package dependencies
 $ make       # build the parser and setup the virtual environment at ./.venv
 ```
 
-Run for all cases and save result to `result.yaml`:
-
-```bash
-$ ./.venv/bin/rna_benchmark --cases cases.yaml --parser bruteforce --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early > result.json
-$ ./.venv/bin/rna_benchmark --cases cases.yaml --parser yaep --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early > result.json
-```
-
 ## Execute
+
+### rna_analysis
 
 For a single sequence. See `--help` for a complete list of options:
 
 ```bash
-$ ./.venv/bin/rna_analysis --parser yaep AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUAACCCC
+$ ./.venv/bin/rna_analysis --sequence AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUAACCCC
+```
+
+### rna_benchmark
+
+Run a benchmark for a number of cases from a YAML file, saving results in JSON format in `result.json`. See [`cases.yaml`](./cases/cases.yaml) for an example YAML file. See `--help` for a list of available options.
+
+```bash
+$ ./.venv/bin/rna_benchmark --cases cases/cases.yaml --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early --parser bruteforce > result.json
+$ ./.venv/bin/rna_benchmark --cases cases/cases.yaml --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early --parser yaep > result.json
 ```
 
 Run benchmark for a number of cases, print output in YAML file. See [`cases.yaml`](./cases.yaml) for an example YAML file:

--- a/knotify/knotify.py
+++ b/knotify/knotify.py
@@ -1,0 +1,207 @@
+#
+# Copyright © 2021 Christos Pavlatos, George Rassias, Christos Andrikos,
+#                  Evangelos Makris, Aggelos Kolaitis
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from typing import Tuple
+
+from oslo_config import cfg
+
+from knotify import hairpin
+from knotify.algorithm.base import BaseAlgorithm
+from knotify.algorithm.ipknot import IPKnot
+from knotify.algorithm.knotify import Knotify
+from knotify.algorithm.knotty import Knotty
+from knotify.algorithm.ihfold import IHFold
+from knotify.algorithm.hotknots import HotKnots
+from knotify.energy.vienna import ViennaEnergy
+from knotify.energy.pkenergy import PKEnergy
+from knotify.parsers.yaep import YaepParser
+from knotify.parsers.bruteforce import BruteForceParser
+
+CSV_OPTS = [
+    cfg.StrOpt("csv"),
+    cfg.StrOpt("results-csv"),
+]
+
+PSEUDOKNOT_OPTS = [
+    cfg.StrOpt("parser", choices=["bruteforce", "yaep"], default="yaep"),
+    cfg.StrOpt("yaep-library-path", default="./libpseudoknot.so"),
+    cfg.StrOpt("bruteforce-library-path", default="./libbruteforce.so"),
+    cfg.BoolOpt("allow-ug", default=False),
+    cfg.BoolOpt("allow-skip-final-au", default=False),
+    cfg.IntOpt("max-dd-size", default=2),
+    cfg.IntOpt("min-dd-size", default=0),
+    cfg.IntOpt("max-window-size", default=204),
+    cfg.IntOpt("min-window-size", default=6),
+    cfg.FloatOpt("max-window-size-ratio", default=0),
+    cfg.FloatOpt("min-window-size-ratio", default=0),
+    cfg.IntOpt("max-stem-allow-smaller", default=2),
+    cfg.BoolOpt("prune-early", default=False),
+]
+
+HAIRPIN_OPTS = [
+    cfg.StrOpt("hairpin-grammar"),
+    cfg.BoolOpt("hairpin-allow-ug"),
+    cfg.IntOpt("min-hairpin-size", default=hairpin.MIN_HAIRPIN_SIZE),
+    cfg.IntOpt("min-hairpin-stems", default=hairpin.MIN_HAIRPIN_STEMS),
+    cfg.IntOpt("max-hairpins-per-loop", default=hairpin.MAX_HAIRPINS_PER_LOOP),
+    cfg.IntOpt("max-hairpin-bulge", default=hairpin.MAX_HAIRPIN_BULGE),
+]
+
+ENERGY_OPTS = [
+    cfg.StrOpt("energy", default="vienna", choices=["vienna", "pkenergy"]),
+    cfg.StrOpt("pkenergy", default="./libpkenergy.so"),
+    cfg.StrOpt("pkenergy-config-dir", default="./pkenergy/hotknots/params"),
+]
+
+ALGORITHM_OPTS = [
+    cfg.StrOpt(
+        "algorithm",
+        default="knotify",
+        choices=["knotify", "ipknot", "knotty", "hotknots", "ihfold"],
+    ),
+    cfg.StrOpt("ipknot-executable", default="./.ipknot/ipknot"),
+    cfg.StrOpt("knotty-executable", default="./.knotty/knotty"),
+    cfg.StrOpt("ihfold-executable", default="./.iterative-hfold/HFold_iterative"),
+    cfg.StrOpt("hotknots-dir", default="./.hotknots/HotKnots_v2.0"),
+]
+
+
+class ConfigOpts(cfg.ConfigOpts):
+    """
+    A cfg.ConfigOpts with added type-hints for the available configuration options.
+    """
+
+    # ALGORITHM_OPTS
+    parser: str
+    yaep_library_path: str
+    bruteforce_library_path: str
+    allow_ug: bool
+    allow_skip_final_au: bool
+    max_dd_size: int
+    min_dd_size: int
+    max_window_size: int
+    min_window_size: int
+    max_window_size_ratio: float
+    min_window_size_ratio: float
+    max_stem_allow_smaller: int
+    prune_early: bool
+
+    # HAIRPIN_OPTS
+    hairpin_grammar: str
+    hairpin_allow_ug: bool
+    min_hairpin_size: int
+    min_hairpin_stems: int
+    max_hairpins_per_loop: int
+    max_hairpin_bulge: int
+
+    # ENERGY_OPTS
+    energy: str
+    pkenergy: str
+    pkenergy_config_dir: str
+
+    # ALGORITHM_OPTS
+    algorithm: str
+    ipknot_executable: str
+    knotty_executable: str
+    ihfold_executable: str
+    hotknots_dir: str
+
+
+def new_options() -> ConfigOpts:
+    """
+    Construct a new options object.
+    """
+    c = ConfigOpts()
+
+    for options in [
+        CSV_OPTS,
+        PSEUDOKNOT_OPTS,
+        ALGORITHM_OPTS,
+        ENERGY_OPTS,
+        HAIRPIN_OPTS,
+    ]:
+        c.register_opts(options)
+        c.register_cli_opts(options)
+
+    return c
+
+
+def from_options(opts: ConfigOpts) -> Tuple[BaseAlgorithm, dict]:
+    """
+    Initialize the knotify execution engine and a dict with configuration.
+    """
+    if opts.hairpin_allow_ug is None:
+        opts.hairpin_allow_ug = opts.allow_ug
+
+    rna_parser_args = {
+        "max_dd_size": opts.max_dd_size,
+        "min_dd_size": opts.min_dd_size,
+        "max_window_size": opts.max_window_size,
+        "min_window_size": opts.min_window_size,
+        "max_window_size_ratio": opts.max_window_size_ratio,
+        "min_window_size_ratio": opts.min_window_size_ratio,
+        "allow_ug": opts.allow_ug,
+    }
+    parser = None
+    if opts.parser == "yaep":
+        parser = YaepParser(opts.yaep_library_path, **rna_parser_args)
+    elif opts.parser == "bruteforce":
+        parser = BruteForceParser(opts.bruteforce_library_path, **rna_parser_args)
+
+    energy = None
+    if opts.energy == "vienna":
+        energy = ViennaEnergy()
+    elif opts.energy == "pkenergy":
+        energy = PKEnergy(opts.pkenergy, opts.pkenergy_config_dir)
+
+    algorithm = None
+    if opts.algorithm == "knotify":
+        algorithm = Knotify()
+    elif opts.algorithm == "ipknot":
+        algorithm = IPKnot()
+    elif opts.algorithm == "knotty":
+        algorithm = Knotty()
+    elif opts.algorithm == "ihfold":
+        algorithm = IHFold()
+    elif opts.algorithm == "hotknots":
+        algorithm = HotKnots()
+
+    return algorithm, {
+        "parser": parser,
+        "csv": opts.csv,
+        "allow_ug": opts.allow_ug,
+        "allow_skip_final_au": opts.allow_skip_final_au,
+        "max_stem_allow_smaller": opts.max_stem_allow_smaller,
+        "prune_early": opts.prune_early,
+        "hairpin_grammar": opts.hairpin_grammar,
+        "hairpin_allow_ug": opts.hairpin_allow_ug,
+        "min_hairpin_size": opts.min_hairpin_size,
+        "min_hairpin_stems": opts.min_hairpin_stems,
+        "max_hairpin_bulge": opts.max_hairpin_bulge,
+        "max_hairpins_per_loop": opts.max_hairpins_per_loop,
+        "energy": energy,
+        "ipknot_executable": opts.ipknot_executable,
+        "knotty_executable": opts.knotty_executable,
+        "ihfold_executable": opts.ihfold_executable,
+        "hotknots_dir": opts.hotknots_dir,
+    }

--- a/knotify/main.py
+++ b/knotify/main.py
@@ -20,160 +20,41 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-import argparse
 from datetime import datetime
+import sys
 
-from knotify import hairpin
-from knotify.algorithm.ipknot import IPKnot
-from knotify.algorithm.knotify import Knotify
-from knotify.algorithm.knotty import Knotty
-from knotify.algorithm.ihfold import IHFold
-from knotify.algorithm.hotknots import HotKnots
-from knotify.energy.vienna import ViennaEnergy
-from knotify.energy.pkenergy import PKEnergy
-from knotify.parsers.yaep import YaepParser
-from knotify.parsers.bruteforce import BruteForceParser
+from oslo_config import cfg
 
+from knotify import knotify
 
-def argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
-
-    # store intermediate results
-    parser.add_argument("--csv")
-    parser.add_argument("--results-csv")
-
-    # pseudoknot arguments
-    parser.add_argument("--parser", choices=["bruteforce", "yaep"])
-    parser.add_argument("--yaep-library-path", default="./libpseudoknot.so")
-    parser.add_argument("--bruteforce-library-path", default="./libbruteforce.so")
-    parser.add_argument("--allow-ug", default=False, action="store_true")
-    parser.add_argument("--allow-skip-final-au", default=False, action="store_true")
-    parser.add_argument("--max-dd-size", default=2, type=int)
-    parser.add_argument("--min-dd-size", default=0, type=int)
-    parser.add_argument("--max-window-size", default=204, type=int)
-    parser.add_argument("--min-window-size", default=6, type=int)
-    parser.add_argument("--max-window-size-ratio", default=0, type=float)
-    parser.add_argument("--min-window-size-ratio", default=0, type=float)
-    parser.add_argument("--max-stem-allow-smaller", default=2, type=int)
-    parser.add_argument("--prune-early", default=False, action="store_true")
-
-    # hairpin arguments
-    parser.add_argument("--hairpin-grammar")
-    parser.add_argument("--hairpin-allow-ug", default=None, action="store_true")
-    parser.add_argument(
-        "--min-hairpin-size", type=int, default=hairpin.MIN_HAIRPIN_SIZE
-    )
-    parser.add_argument(
-        "--min-hairpin-stems", type=int, default=hairpin.MIN_HAIRPIN_STEMS
-    )
-    parser.add_argument(
-        "--max-hairpins-per-loop", type=int, default=hairpin.MAX_HAIRPINS_PER_LOOP
-    )
-    parser.add_argument(
-        "--max-hairpin-bulge", type=int, default=hairpin.MAX_HAIRPIN_BULGE
-    )
-
-    # energy arguments
-    parser.add_argument("--energy", choices=["vienna", "pkenergy"], default="vienna")
-    parser.add_argument("--pkenergy", default="./libpkenergy.so")
-    parser.add_argument("--pkenergy-config-dir", default="pkenergy/hotknots/params")
-
-    # overrides for other algorithms
-    parser.add_argument(
-        "--algorithm",
-        choices=["knotify", "ipknot", "knotty", "hotknots", "ihfold"],
-        default="knotify",
-    )
-    parser.add_argument("--ipknot-executable", default="./.ipknot/ipknot")
-    parser.add_argument("--knotty-executable", default="./.knotty/knotty")
-    parser.add_argument(
-        "--ihfold-executable", default="./.iterative-hfold/HFold_iterative"
-    )
-    parser.add_argument("--hotknots-dir", default="./.hotknots/HotKnots_v2.0")
-
-    return parser
-
-
-def config_from_arguments(args: argparse.Namespace) -> dict:
-    if args.hairpin_allow_ug is None:
-        args.hairpin_allow_ug = args.allow_ug
-
-    rna_parser_args = {
-        "max_dd_size": args.max_dd_size,
-        "min_dd_size": args.min_dd_size,
-        "max_window_size": args.max_window_size,
-        "min_window_size": args.min_window_size,
-        "max_window_size_ratio": args.max_window_size_ratio,
-        "min_window_size_ratio": args.min_window_size_ratio,
-        "allow_ug": args.allow_ug,
-    }
-    parser = None
-    if args.parser == "yaep":
-        parser = YaepParser(args.yaep_library_path, **rna_parser_args)
-    elif args.parser == "bruteforce":
-        parser = BruteForceParser(args.bruteforce_library_path, **rna_parser_args)
-
-    energy = None
-    if args.energy == "vienna":
-        energy = ViennaEnergy()
-    elif args.energy == "pkenergy":
-        energy = PKEnergy(args.pkenergy, args.pkenergy_config_dir)
-
-    algorithm = None
-    if args.algorithm == "knotify":
-        algorithm = Knotify()
-    elif args.algorithm == "ipknot":
-        algorithm = IPKnot()
-    elif args.algorithm == "knotty":
-        algorithm = Knotty()
-    elif args.algorithm == "ihfold":
-        algorithm = IHFold()
-    elif args.algorithm == "hotknots":
-        algorithm = HotKnots()
-
-    return {
-        "algorithm": algorithm,
-        "parser": parser,
-        "csv": args.csv,
-        "allow_ug": args.allow_ug,
-        "allow_skip_final_au": args.allow_skip_final_au,
-        "max_stem_allow_smaller": args.max_stem_allow_smaller,
-        "prune_early": args.prune_early,
-        "hairpin_grammar": args.hairpin_grammar,
-        "hairpin_allow_ug": args.hairpin_allow_ug,
-        "min_hairpin_size": args.min_hairpin_size,
-        "min_hairpin_stems": args.min_hairpin_stems,
-        "max_hairpin_bulge": args.max_hairpin_bulge,
-        "max_hairpins_per_loop": args.max_hairpins_per_loop,
-        "energy": energy,
-        "ipknot_executable": args.ipknot_executable,
-        "knotty_executable": args.knotty_executable,
-        "ihfold_executable": args.ihfold_executable,
-        "hotknots_dir": args.hotknots_dir,
-    }
+OPTS = [
+    cfg.StrOpt("sequence"),
+]
 
 
 def main():
+    options = knotify.new_options()
+    options.register_cli_opts(OPTS)
+    options()
 
-    # define the argument parser
-    parser = argument_parser()
-    parser.add_argument("sequence")
+    if not options.sequence:
+        print("Missing required parameter --sequence")
+        sys.exit(1)
 
-    args = parser.parse_args()
-
-    config = config_from_arguments(args)
-    algorithm = config["algorithm"]
+    algorithm, config = knotify.from_options(options)
 
     start = datetime.now()
-    results = algorithm.get_results(sequence=args.sequence.lower(), **config)
+    results = algorithm.get_results(sequence=options.sequence.lower(), **config)
     duration = datetime.now() - start
 
-    if args.results_csv:
-        results[["dot_bracket", "stems", "energy"]].to_csv(args.results_csv, index=None)
+    if options.results_csv:
+        results[["dot_bracket", "stems", "energy"]].to_csv(
+            options.results_csv, index=None
+        )
 
     chosen = results.loc[0]
 
-    print("Sequence: ", args.sequence)
+    print("Sequence: ", options.sequence)
     print("Structure:", chosen.dot_bracket)
     print("Energy:", chosen.energy)
     print("Duration:", duration.total_seconds(), "s")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas==1.2.2
 levenshtein==0.12.0
 jinja2==3.0.3
 pyyaml==5.4.1
+oslo-config==8.8.0


### PR DESCRIPTION
### Summary

Use structured configuration options using oslo.config instead of relying on argparse.

This allows specifying configuration using command line arguments, configuration files and environment variables. Further, it makes it easier to construct configuration option objects, in order to make knotify easier to use directly from Python code.

### Testing

Existing unit tests, as well as the added smoke tests make sure that nothing breaks in the process