### PR TITLE
Pass configuration using environment variables

### DIFF
--- a/knotify/knotify.py
+++ b/knotify/knotify.py
@@ -89,7 +89,14 @@ ALGORITHM_OPTS = [
 class ConfigOpts(cfg.ConfigOpts):
     """
     A cfg.ConfigOpts with added type-hints for the available configuration options.
+
+    Configuration can also be loaded from environment variables, using KNOTIFY_$OPTION_NAME,
+    e.g. KNOTIFY_YAEP_LIBRARY_PATH.
     """
+
+    def __init__(self, *args, **kwargs):
+        super(ConfigOpts, self).__init__(*args, **kwargs)
+        self._env_driver.get_name = lambda _, opt: "KNOTIFY_{}".format(opt.upper())
 
     # ALGORITHM_OPTS
     parser: str

--- a/scripts/00-example.py
+++ b/scripts/00-example.py
@@ -47,6 +47,9 @@ def main():
     #
     # options.yaep_library_path = "/opt/knotify/lib/libpseudoknot.so"
 
+    # load configuration from environment variables
+    options(args=[])
+
     # initialize the knotify engine from options
     algorithm, config = knotify.from_options(options)
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,51 @@
+#
+# Copyright © 2022 Christos Pavlatos, George Rassias, Christos Andrikos,
+#                  Evangelos Makris, Aggelos Kolaitis
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+import os
+from typing import Any
+
+import pytest
+
+from knotify import knotify
+from knotify.algorithm.base import BaseAlgorithm
+
+
+@pytest.mark.parametrize(
+    "env_opt,env_val,opt,val",
+    [
+        ("KNOTIFY_ALLOW_SKIP_FINAL_AU", "True", "allow_skip_final_au", True),
+        ("KNOTIFY_ALLOW_SKIP_FINAL_AU", "False", "allow_skip_final_au", False),
+        ("KNOTIFY_ALLOW_UG", "1", "allow_ug", True),
+        ("KNOTIFY_ALLOW_UG", "0", "allow_ug", False),
+        ("KNOTIFY_MAX_HAIRPIN_BULGE", "2", "max_hairpin_bulge", 2),
+        ("KNOTIFY_MAX_HAIRPIN_BULGE", "4", "max_hairpin_bulge", 4),
+    ],
+)
+def test_environment(env_opt: str, env_val: str, opt: str, val: Any):
+    opts = knotify.new_options()
+    os.environ[env_opt] = env_val
+    opts(args=[])
+
+    algorithm, config = knotify.from_options(opts)
+
+    assert isinstance(algorithm, BaseAlgorithm)
+    assert config[opt] == val


### PR DESCRIPTION
### Summary

Support passing configuration options to knotify using environment variables.

For each option, the respective environment variable is `KNOTIFY_$NAME`

For example, for the option `yaep_library_path`, the environment variable name will be `KNOTIFY_YAEP_LIBRARY_PATH`.