### PR TITLE
Do not build yaep in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lib%.so: parsers/%.c $(YAEP_DIR)/src/libyaep.a
 
 $(YAEP_DIR)/src/libyaep.a:
 	git clone https://github.com/ntua-dslab/yaep --depth 1 $(YAEP_DIR)
-	cd $(YAEP_DIR) && ./configure CFLAGS=-fPIC && make -j
+	cd $(YAEP_DIR) && ./configure CFLAGS=-fPIC && make
 
 #####################################################
 # PK energy


### PR DESCRIPTION
## Summary

There is a race condition in the yaep makefile causing
the compilation to fail with the following error:

sgramm.c: No such file or directory
 3425 | #include "sgramm.c"
      |          ^~~~~~~~~~

sgramm.c is generated dynamically. To prevent the
race condition, simply build yaep in serial mode