### PR TITLE
speedup: Parse core stems using ctypes callbacks

### DIFF
--- a/knotify/rna_analysis.py
+++ b/knotify/rna_analysis.py
@@ -106,9 +106,7 @@ class StringAnalyser(object):
         pseudoknots = []
         max_size = 0
         for line in self.parser.detect_pseudoknots(self.sequence):
-            if not line:
-                continue
-            i, j, left_loop_size, dd_size = map(int, line.split(","))
+            i, j, left_loop_size, dd_size = line
             knot = self._get_pseudoknots_for_tree(i, j, left_loop_size, dd_size)
             size = len(knot.right_loop_stems[0]) + len(knot.left_loop_stems[0])
             if knot and (not prune_early or size >= max_size - max_stem_allow_smaller):

--- a/parsers/bruteforce.c
+++ b/parsers/bruteforce.c
@@ -60,11 +60,7 @@ void initialize(char *_grammar_unused, int _allow_ug, int _min_dd_size,
   //        min_window_size, max_window_size);
 }
 
-char *detect_pseudoknots(char *sequence) {
-  char *buffer;
-  size_t size;
-  FILE *fp = open_memstream(&buffer, &size);
-
+void detect_pseudoknots(char *sequence, void (*cb)(int, int, int, int)) {
   int n = strlen(sequence);
 
   // window size is static or ratio of sequence length
@@ -178,8 +174,7 @@ char *detect_pseudoknots(char *sequence) {
       continue;
     }
 
-    fprintf(fp, "%d,%d,%d,%d\n", left, size, left_loop_size, dd_size);
-
+    cb(left, size, left_loop_size, dd_size);
     // printf("(%d %d) - (%d %d) \t\t (%c, %c) - (%c, %c) \n",
     //        (ccs_position->cstem[0]).left, (ccs_position->cstem[0]).right,
     //        (ccs_position->cstem[1]).left, (ccs_position->cstem[1]).right,
@@ -189,16 +184,4 @@ char *detect_pseudoknots(char *sequence) {
     //        sequence[(ccs_position->cstem[1]).right]);
     ccs_position++;
   }
-
-  fclose(fp);
-  return buffer;
-}
-
-int main(int argc, char *argv[]) {
-  if (argc != 2) {
-    printf("Wrong number of arguments!!!\n");
-    exit(0);
-  }
-  // printf("%ld %ld \n", n_stems, n_cstems);
-  return 0;
 }

--- a/parsers/pseudoknot.c
+++ b/parsers/pseudoknot.c
@@ -425,12 +425,9 @@ struct pseudoknot *traverse_parse_tree(struct yaep_tree_node *node) {
   }
 }
 
-char *detect_pseudoknots(char *sequence) {
+void detect_pseudoknots(char *sequence, void (*cb)(int, int, int, int)) {
   s_input = sequence;
 
-  char *buffer;
-  size_t size;
-  FILE *fp = open_memstream(&buffer, &size);
   int len = strlen(sequence);
 
   // The loop variables ensure that in every outer iteration we can discard the
@@ -455,17 +452,15 @@ char *detect_pseudoknots(char *sequence) {
         if (i->dd_size < s_min_dd_size) {
           continue;
         }
-        fprintf(fp, "%d,%d,%d,%d\n", left, right - left + 1, i->left_loop_size,
-                i->dd_size);
+        cb(left, right - left + 1, i->left_loop_size, i->dd_size);
+        // fprintf(fp, "%d,%d,%d,%d\n", left, right - left + 1,
+        // i->left_loop_size, i->dd_size);
       }
     }
 
     // we finished all windows where the last character is used, now discard
     s_input[right] = '\0';
   }
-
-  fclose(fp);
-  return buffer;
 }
 
 void initialize(char *_grammar, int _allow_ug, int _min_dd_size,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,12 +33,12 @@ from tests.utils import for_each_parser
 @pytest.mark.parametrize(
     "dd_size, sequence, result",
     [
-        (1, "caaaaaggaaaaac", ["0,14,5,0"]),
-        (1, "caaaaagagaaaaac", ["0,15,5,1"]),
-        (1, "caaaaagaagaaaaac", [""]),
-        (2, "caaaaagaagaaaaac", ["0,16,5,2"]),
-        (2, "caaaaagaaagaaaaac", [""]),
-        (3, "caaaaagaaagaaaaac", ["0,17,5,3"]),
+        (1, "caaaaaggaaaaac", [(0, 14, 5, 0)]),
+        (1, "caaaaagagaaaaac", [(0, 15, 5, 1)]),
+        (1, "caaaaagaagaaaaac", []),
+        (2, "caaaaagaagaaaaac", [(0, 16, 5, 2)]),
+        (2, "caaaaagaaagaaaaac", []),
+        (3, "caaaaagaaagaaaaac", [(0, 17, 5, 3)]),
     ],
 )
 def test_max_dd_size(
@@ -63,25 +63,25 @@ def test_pseudoknot_pairs(parser, library_path, A, B, allow_ug):
 
     result = p.detect_pseudoknots("{}aaa{}a{}aaa{}".format(A[0], B[0], A[1], B[1]))
     if not combination_has_ug or combination_has_ug and allow_ug:
-        assert "0,11,3,1" in result
+        assert (0, 11, 3, 1) in result
     if combination_has_ug and not allow_ug:
-        assert "0,11,3,1" not in result
+        assert (0, 11, 3, 1) not in result
 
     result = p.detect_pseudoknots("a{}aaa{}a{}aaa{}aaa".format(A[0], B[0], A[1], B[1]))
     if not combination_has_ug or combination_has_ug and allow_ug:
-        assert "1,11,3,1" in result
+        assert (1, 11, 3, 1) in result
     if combination_has_ug and not allow_ug:
-        assert "1,11,3,1" not in result
+        assert (1, 11, 3, 1) not in result
 
 
 @for_each_parser("parser, library_path")
 @pytest.mark.parametrize(
     "sequence, result",
     [
-        ("caaaaaggaaaaac", ["0,14,5,0"]),
-        ("caaaaagagaaaaac", ["0,15,5,1"]),
-        ("caaaaagaagaaaaac", ["0,16,5,2"]),
-        ("caaaaagaaagaaaaac", ["0,17,5,3"]),
+        ("caaaaaggaaaaac", [(0, 14, 5, 0)]),
+        ("caaaaagagaaaaac", [(0, 15, 5, 1)]),
+        ("caaaaagaagaaaaac", [(0, 16, 5, 2)]),
+        ("caaaaagaaagaaaaac", [(0, 17, 5, 3)]),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is faster and requires less memory than writing to a string buffer and parsing it in Python code.