### PR TITLE
Update README and Docker instructions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,18 @@
+---
+name: Docker Image
+
+on: [push]
+
+jobs:
+  test:
+    name: Docker Image
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Docker Image
+        run: |
+          docker build -t knotify:dev .
+      - name: Test Docker Image
+        run: |
+          docker run knotify:dev /knotify/bin/rna_analysis --sequence AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUAACCCC

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Build package
-        run: make deps && make -j && make knotty ipknot ihfold hotknots
+        run: make deps && make && make knotty ipknot ihfold hotknots
       - name: Check formatting
         run: .venv/bin/black . --check
       - name: Test binary

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Build package
-        run: make deps && make -j
+        run: make deps && make
       - name: python
         run: ./.venv/bin/python ./scripts/00-example.py
       - name: rna_analysis

--- a/Makefile
+++ b/Makefile
@@ -119,33 +119,28 @@ $(HOTKNOTS_DIR)/HotKnots_v2.0/bin/HotKnots: hotknots-deps $(HOTKNOTS_DIR)/HotKno
 
 IHFOLD_DIR = .ihfold
 
-ihfold: $(IHFOLD_DIR)/v1/HFold_iterative $(IHFOLD_DIR)/v2/Iterative-HFold
+ihfold: $(IHFOLD_DIR)/v1/HFold_iterative $(IHFOLD_DIR)/v2/Iterative-HFold $(IHFOLD_DIR)/v3/Iterative-HFold
 
-ihfold-deps:
+ihfold-deps: $(IHFOLD_DIR)/dev/Iterative-HFold.cpp
 	sudo apt-get install -y cmake
 
+$(IHFOLD_DIR)/dev/Iterative-HFold.cpp:
+	git clone https://github.com/HosnaJabbari/Iterative-HFold $(IHFOLD_DIR)/dev
+
 $(IHFOLD_DIR)/v1/HFold_iterative: ihfold-deps
-	git clone https://github.com/HosnaJabbari/Iterative-HFold $(IHFOLD_DIR)/v1
+	git clone $(IHFOLD_DIR)/dev $(IHFOLD_DIR)/v1
 	cd $(IHFOLD_DIR)/v1 && git checkout c77dd839943c85f9e0c9db3b3e8feae2909b9df0
 	cd $(IHFOLD_DIR)/v1 && cmake . && make -j
 
 $(IHFOLD_DIR)/v2/Iterative-HFold: ihfold-deps
-	git clone https://github.com/HosnaJabbari/Iterative-HFold $(IHFOLD_DIR)/v2 --depth 1
+	git clone $(IHFOLD_DIR)/dev $(IHFOLD_DIR)/v2
+	cd $(IHFOLD_DIR)/v2 && git checkout 56d736b224027fe2627ebde66ebf2e7557997638
 	cd $(IHFOLD_DIR)/v2 && cmake . && make -j
 
-#####################################################
-# Iterative-HFold
-
-IHFOLDV2_DIR = .ihfoldv2
-
-ihfoldv2: $(IHFOLDV2_DIR)/Iterative-HFold
-
-ihfoldv2-deps:
-	sudo apt-get install -y cmake
-
-$(IHFOLDV2_DIR)/Iterative-HFold: ihfoldv2-deps
-	git clone https://github.com/HosnaJabbari/Iterative-HFold --depth 1 $(IHFOLDV2_DIR)
-	cd $(IHFOLDV2_DIR) && cmake . && make -j
+$(IHFOLD_DIR)/v3/Iterative-HFold: ihfold-deps
+	git clone $(IHFOLD_DIR)/dev $(IHFOLD_DIR)/v3
+	cd $(IHFOLD_DIR)/v3 && git checkout 672b11e4e8050a8e6133c635ebfed4c0c37912e8
+	cd $(IHFOLD_DIR)/v3 && cmake . && make -j
 
 #####################################################
 # Clean

--- a/README.md
+++ b/README.md
@@ -8,23 +8,31 @@ Authors: Andrikos Christos, Makris Evaggelos, Pavlatos Christos, Rassias Georgio
 
 ## Run with Docker
 
-```bash
-docker run --rm -it neoaggelos/knotify /knotify/bin/rna_analysis --sequence AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUAACCCC
-```
-
-### Build Image
+`knotify` is written in a mix of Python and C code. The easiest way to run it is to build the Docker image and then run as follows. We do not currently provide pre-built Docker images, but that might change in the future.
 
 ```bash
-docker build -t knotify:0.0.1 .
+# build docker image and tag as `knotify:dev`
+docker build -t knotify:dev .
+
+# run an example 'rna_analysis'
+docker run --rm -it knotify:dev /knotify/bin/rna_analysis --sequence AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUAACCCC
 ```
 
 ## Development Environment
 
-Building the code consists of 2 parts: Setting up a Python 3 virtual environment and building the C parser library.
+`knotify` has binary depedendencies that require running on a Ubuntu 20.04 system. Building the code consists of 2 parts: Setting up a Python 3 virtual environment and building the C parser libraries.
+
+Note that the instructions below will probably not work on newer Ubuntu systems or different Linux distributions (e.g. CentOS). This is because of the [wheel-requirements.txt](./wheel-requirements.txt) pinning the ViennaRNA C library to the ubuntu2004 version, which requires a specific glibc version. In the future, we will build ViennaRNA from source to avoid this restriction.
 
 ```bash
 $ make deps  # install package dependencies
 $ make       # build the parser and setup the virtual environment at ./.venv
+```
+
+After installation, make sure to activate the virtual environment before running any of the commands below:
+
+```bash
+$ . ./.venv/bin/activate
 ```
 
 ## Execute
@@ -34,7 +42,7 @@ $ make       # build the parser and setup the virtual environment at ./.venv
 For a single sequence. See `--help` for a complete list of options:
 
 ```bash
-$ ./.venv/bin/rna_analysis --sequence AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUAACCCC
+$ rna_analysis --sequence AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUAACCCC
 ```
 
 ### rna_benchmark
@@ -42,8 +50,8 @@ $ ./.venv/bin/rna_analysis --sequence AAAAAACUAAUAGAGGGGGGACUUAGCGCCCCCCAAACCGUA
 Run a benchmark for a number of cases from a YAML file, saving results in JSON format in `result.json`. See [`cases.yaml`](./cases/cases.yaml) for an example YAML file. See `--help` for a list of available options.
 
 ```bash
-$ ./.venv/bin/rna_benchmark --cases cases/cases.yaml --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early --parser bruteforce > result.json
-$ ./.venv/bin/rna_benchmark --cases cases/cases.yaml --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early --parser yaep > result.json
+$ rna_benchmark --cases cases/cases.yaml --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early --parser bruteforce > result.json
+$ rna_benchmark --cases cases/cases.yaml --max-dd-size 2 --max-stem-allow-smaller 1 --allow-ug --prune-early --parser yaep > result.json
 ```
 
 ### Calling directly from Python code
@@ -52,10 +60,10 @@ See [`scripts/00-example.py`](./scripts/00-example.py) for using `knotify` direc
 
 ## Unit Tests
 
-Activate virtual environment and run with Pytest:
+We use `pytest` for all unit tests. After enabling the virtual environment, you can run them with:
 
 ```bash
-$ ./.venv/bin/pytest
+$ pytest
 ```
 
 ## Implementation details

--- a/knotify/algorithm/ihfold.py
+++ b/knotify/algorithm/ihfold.py
@@ -146,7 +146,9 @@ class IHFoldV3(BaseAlgorithm):
         p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if p.returncode != 0:
-            LOG.warning("ihfold invocation %s failed with return code %d", cmd, p.returncode)
+            LOG.warning(
+                "ihfold invocation %s failed with return code %d", cmd, p.returncode
+            )
 
         try:
             result = parse_output(p.stdout.decode(), PATTERN_V3)

--- a/knotify/knotify.py
+++ b/knotify/knotify.py
@@ -30,7 +30,7 @@ from knotify.algorithm.base import BaseAlgorithm
 from knotify.algorithm.ipknot import IPKnot
 from knotify.algorithm.knotify import Knotify
 from knotify.algorithm.knotty import Knotty
-from knotify.algorithm.ihfold import IHFold, IHFoldV2
+from knotify.algorithm.ihfold import IHFold, IHFoldV2, IHFoldV3
 from knotify.algorithm.hotknots import HotKnots
 from knotify.energy.vienna import ViennaEnergy
 from knotify.energy.external import ExternalEnergy
@@ -102,12 +102,21 @@ ALGORITHM_OPTS = [
     cfg.StrOpt(
         "algorithm",
         default="knotify",
-        choices=["knotify", "ipknot", "knotty", "hotknots", "ihfold", "ihfoldv2"],
+        choices=[
+            "knotify",
+            "ipknot",
+            "knotty",
+            "hotknots",
+            "ihfold",
+            "ihfoldv2",
+            "ihfoldv3",
+        ],
     ),
     cfg.StrOpt("ipknot-executable", default="./.ipknot/ipknot"),
     cfg.StrOpt("knotty-executable", default="./.knotty/knotty"),
     cfg.StrOpt("ihfold-executable", default="./.ihfold/v1/HFold_iterative"),
     cfg.StrOpt("ihfoldv2-executable", default="./.ihfold/v2/Iterative-HFold"),
+    cfg.StrOpt("ihfoldv3-executable", default="./.ihfold/v3/Iterative-HFold"),
     cfg.StrOpt("hotknots-dir", default="./.hotknots/HotKnots_v2.0"),
 ]
 
@@ -170,6 +179,7 @@ class ConfigOpts(cfg.ConfigOpts):
     knotty_executable: str
     ihfold_executable: str
     ihfoldv2_executable: str
+    ihfoldv3_executable: str
     hotknots_dir: str
 
 
@@ -234,6 +244,8 @@ def from_options(opts: ConfigOpts) -> Tuple[BaseAlgorithm, dict]:
         algorithm = IHFold()
     elif opts.algorithm == "ihfoldv2":
         algorithm = IHFoldV2()
+    elif opts.algorithm == "ihfoldv3":
+        algorithm = IHFoldV3()
     elif opts.algorithm == "hotknots":
         algorithm = HotKnots()
 

--- a/tests/unit/test_foreign.py
+++ b/tests/unit/test_foreign.py
@@ -158,6 +158,7 @@ def test_hotknots_parse(stdout, result):
         (hotknots.HotKnots(), "hotknots_dir", "./.hotknots/HotKnots_v2.0"),
         (ihfold.IHFold(), "ihfold_executable", "./.ihfold/v1/HFold_iterative"),
         (ihfold.IHFoldV2(), "ihfoldv2_executable", "./.ihfold/v2/Iterative-HFold"),
+        (ihfold.IHFoldV3(), "ihfoldv3_executable", "./.ihfold/v3/Iterative-HFold"),
     ],
 )
 def test_foreign_smoke(algorithm, executable, path):

--- a/tests/unit/test_foreign.py
+++ b/tests/unit/test_foreign.py
@@ -100,6 +100,29 @@ def test_ihfoldv2_parse(stdout, result):
     assert ihfold.parse_output(stdout, ihfold.PATTERN_V2) == result
 
 
+IHFOLDV3_OUTPUT = """
+GGCACGAUCGGGCUCGCUGCCUUUUCGUCCGAGAGCUCGAA
+[[[[...((((((((..]]]]...........)))))))). (-10.15)
+"""
+
+
+@pytest.mark.parametrize(
+    "stdout, result",
+    [
+        (
+            IHFOLDV3_OUTPUT,
+            {
+                "dot_bracket": "[[[[...((((((((..]]]]...........)))))))).",
+                "stems": 24,
+                "energy": -10.15,
+            },
+        ),
+    ],
+)
+def test_ihfoldv3_parse(stdout, result):
+    assert ihfold.parse_output(stdout, ihfold.PATTERN_V3) == result
+
+
 HOTKNOTS_OUTPUT = (
     "Total number of RNA structures: 1\nSeq: AUGAAAG\nS0:  .([.)].\t-3.2\n"
 )


### PR DESCRIPTION
### Summary

Freshen up the Docker and development instructions on `README.md`. Make it clear that we currently require Ubuntu 20.04 when developing due to the vienna RNA binary wheel glibc version.

Also touch up ihfold tests, as the output has changed in the latest version.